### PR TITLE
Update to mio 0.8 and os_pipe 1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["/.github"]
 rustc_version = "0.4.0"
 
 [dependencies]
-io-lifetimes = { version = "0.3.3", default-features = false }
+io-lifetimes = { version = "0.4.0", default-features = false }
 
 # Optionally depend on async-std to implement traits for its types.
 #
@@ -24,11 +24,11 @@ async-std = { version = "1.9.0", features = ["unstable"], optional = true }
 # Optionally depend on tokio to implement traits for its types.
 tokio = { version = "1.6.0", features = ["io-std", "fs", "net", "process"], optional = true }
 # Optionally depend on os_pipe to implement traits for its types.
-os_pipe = { version = "0.9.2", optional = true }
+os_pipe = { version = "1.0.0", optional = true }
 # Optionally depend on socket2 to implement traits for its types.
 socket2 = { version = "0.4.0", optional = true }
 # Optionally depend on mio to implement traits for its types.
-mio = { version = "0.7.11", optional = true }
+mio = { version = "0.8.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = [
@@ -41,7 +41,7 @@ winapi = { version = "0.3.9", features = [
 ] }
 
 [dev-dependencies]
-os_pipe = "0.9.2"
+os_pipe = "1.0.0"
 
 [features]
 default = []

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -486,14 +486,6 @@ impl AsRawHandleOrSocket for mio::net::TcpListener {
 }
 
 #[cfg(feature = "use_mio_net")]
-impl AsRawHandleOrSocket for mio::net::TcpSocket {
-    #[inline]
-    fn as_raw_handle_or_socket(&self) -> RawHandleOrSocket {
-        RawHandleOrSocket::unowned_from_raw_socket(Self::as_raw_socket(self))
-    }
-}
-
-#[cfg(feature = "use_mio_net")]
 impl AsRawHandleOrSocket for mio::net::UdpSocket {
     #[inline]
     fn as_raw_handle_or_socket(&self) -> RawHandleOrSocket {
@@ -584,14 +576,6 @@ impl IntoRawHandleOrSocket for mio::net::TcpStream {
 
 #[cfg(feature = "use_mio_net")]
 impl IntoRawHandleOrSocket for mio::net::TcpListener {
-    #[inline]
-    fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
-        RawHandleOrSocket::unowned_from_raw_socket(Self::into_raw_socket(self))
-    }
-}
-
-#[cfg(feature = "use_mio_net")]
-impl IntoRawHandleOrSocket for mio::net::TcpSocket {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         RawHandleOrSocket::unowned_from_raw_socket(Self::into_raw_socket(self))

--- a/src/os/windows/traits.rs
+++ b/src/os/windows/traits.rs
@@ -334,14 +334,6 @@ impl AsHandleOrSocket for mio::net::TcpListener {
 }
 
 #[cfg(feature = "use_mio_net")]
-impl AsHandleOrSocket for mio::net::TcpSocket {
-    #[inline]
-    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
-        BorrowedHandleOrSocket::from_socket(Self::as_socket(self))
-    }
-}
-
-#[cfg(feature = "use_mio_net")]
 impl AsHandleOrSocket for mio::net::UdpSocket {
     #[inline]
     fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
@@ -432,14 +424,6 @@ impl IntoHandleOrSocket for mio::net::TcpStream {
 
 #[cfg(feature = "use_mio_net")]
 impl IntoHandleOrSocket for mio::net::TcpListener {
-    #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_socket(Self::into_socket(self))
-    }
-}
-
-#[cfg(feature = "use_mio_net")]
-impl IntoHandleOrSocket for mio::net::TcpSocket {
     #[inline]
     fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
         OwnedHandleOrSocket::from_socket(Self::into_socket(self))

--- a/src/read_write.rs
+++ b/src/read_write.rs
@@ -672,58 +672,6 @@ impl AsReadWriteHandleOrSocket for mio::net::TcpStream {
 }
 
 #[cfg(all(not(windows), feature = "use_mio_net"))]
-impl AsRawReadWriteFd for mio::net::TcpSocket {
-    #[inline]
-    fn as_raw_read_fd(&self) -> RawFd {
-        self.as_raw_fd()
-    }
-
-    #[inline]
-    fn as_raw_write_fd(&self) -> RawFd {
-        self.as_raw_fd()
-    }
-}
-
-#[cfg(all(not(windows), feature = "use_mio_net"))]
-impl AsReadWriteFd for mio::net::TcpSocket {
-    #[inline]
-    fn as_read_fd(&self) -> BorrowedFd<'_> {
-        self.as_fd()
-    }
-
-    #[inline]
-    fn as_write_fd(&self) -> BorrowedFd<'_> {
-        self.as_fd()
-    }
-}
-
-#[cfg(all(windows, feature = "use_mio_net"))]
-impl AsRawReadWriteHandleOrSocket for mio::net::TcpSocket {
-    #[inline]
-    fn as_raw_read_handle_or_socket(&self) -> RawHandleOrSocket {
-        self.as_raw_handle_or_socket()
-    }
-
-    #[inline]
-    fn as_raw_write_handle_or_socket(&self) -> RawHandleOrSocket {
-        self.as_raw_handle_or_socket()
-    }
-}
-
-#[cfg(all(windows, feature = "use_mio_net"))]
-impl AsReadWriteHandleOrSocket for mio::net::TcpSocket {
-    #[inline]
-    fn as_read_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
-        self.as_handle_or_socket()
-    }
-
-    #[inline]
-    fn as_write_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
-        self.as_handle_or_socket()
-    }
-}
-
-#[cfg(all(not(windows), feature = "use_mio_net"))]
 impl AsRawReadWriteFd for mio::net::UdpSocket {
     #[inline]
     fn as_raw_read_fd(&self) -> RawFd {


### PR DESCRIPTION
mio's `TcpSocket` was removed in favor of socket2.