### PR TITLE
Add `as_{handle,socket}` to the `{Owned,Borrowed}HandleOrSocket` types.

### DIFF
--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -89,11 +89,11 @@ impl RawHandleOrSocket {
     /// it can return `None` if `self` doesn't contain a `RawHandle`.
     #[inline]
     #[must_use]
-    pub fn as_unowned_raw_handle(&self) -> Option<RawHandle> {
+    pub fn as_raw_handle(&self) -> Option<RawHandle> {
         match self.0 {
             RawEnum::Handle(raw_handle) => Some(raw_handle),
             RawEnum::Socket(_) => None,
-            RawEnum::Stdio(ref stdio) => Some(stdio.as_unowned_raw_handle()),
+            RawEnum::Stdio(ref stdio) => Some(stdio.as_raw_handle()),
         }
     }
 
@@ -101,7 +101,7 @@ impl RawHandleOrSocket {
     /// it can return `None` if `self` doesn't contain a `RawSocket`.
     #[inline]
     #[must_use]
-    pub const fn as_unowned_raw_socket(&self) -> Option<RawSocket> {
+    pub const fn as_raw_socket(&self) -> Option<RawSocket> {
         match self.0 {
             RawEnum::Handle(_) | RawEnum::Stdio(_) => None,
             RawEnum::Socket(raw_socket) => Some(raw_socket),

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -4,15 +4,7 @@
 //! accompanying `AsRawFd`, `IntoRawFd`, and `FromRawFd` traits.
 //!
 //! These types are only defined on Windows and do not require implementors to
-//! assert that they own their resources. See [`UnsafeHandle`] and
-//! accompanying [`AsUnsafeHandle`], [`IntoRawHandle`], and
-//! [`FromUnsafeHandle`] traits for platform-independent interfaces which do
-//! include ownership assertions.
-//!
-//! [`UnsafeHandle`]: crate::UnsafeHandle
-//! [`AsUnsafeHandle`]: crate::AsUnsafeHandle
-//! [`IntoUnsafeHandle`]: crate::IntoUnsafeHandle
-//! [`FromUnsafeHandle`]: crate::FromUnsafeHandle
+//! assert that they own their resources.
 
 #[cfg(any(test, feature = "os_pipe"))]
 use os_pipe::{PipeReader, PipeWriter};

--- a/src/os/windows/stdio.rs
+++ b/src/os/windows/stdio.rs
@@ -66,7 +66,7 @@ impl Stdio {
     }
 
     #[inline]
-    pub(crate) fn as_unowned_raw_handle(self) -> RawHandle {
+    pub(crate) fn as_raw_handle(self) -> RawHandle {
         get_handle(self.id).unwrap()
     }
 }

--- a/src/os/windows/types.rs
+++ b/src/os/windows/types.rs
@@ -62,6 +62,40 @@ impl<'a> BorrowedHandleOrSocket<'a> {
             _phantom: PhantomData,
         }
     }
+
+    /// Like [`AsHandle::as_handle`], but returns an `Option` so that
+    /// it can return `None` if `self` doesn't contain a `BorrowedHandle`.
+    ///
+    /// [`AsHandle::as_handle`]: std::os::windows::io::AsHandle::as_handle
+    #[inline]
+    #[must_use]
+    pub fn as_handle(&self) -> Option<BorrowedHandle> {
+        unsafe {
+            match self.raw.0 {
+                RawEnum::Handle(handle) => Some(BorrowedHandle::borrow_raw_handle(handle)),
+                RawEnum::Socket(_) => None,
+                RawEnum::Stdio(ref stdio) => {
+                    Some(BorrowedHandle::borrow_raw_handle(stdio.as_raw_handle()))
+                }
+            }
+        }
+    }
+
+    /// Like [`AsSocket::as_socket`], but returns an `Option` so that
+    /// it can return `None` if `self` doesn't contain a `BorrowedSocket`.
+    ///
+    /// [`AsSocket::as_socket`]: std::os::windows::io::AsSocket::as_socket
+    #[inline]
+    #[must_use]
+    pub fn as_socket(&self) -> Option<BorrowedSocket> {
+        unsafe {
+            match self.raw.0 {
+                RawEnum::Handle(_) => None,
+                RawEnum::Socket(socket) => Some(BorrowedSocket::borrow_raw_socket(socket)),
+                RawEnum::Stdio(_) => None,
+            }
+        }
+    }
 }
 
 impl OwnedHandleOrSocket {
@@ -95,6 +129,40 @@ impl OwnedHandleOrSocket {
     pub fn from_socket(socket: OwnedSocket) -> Self {
         Self {
             raw: RawHandleOrSocket(RawEnum::Socket(socket.as_raw_socket())),
+        }
+    }
+
+    /// Like [`AsHandle::as_handle`], but returns an `Option` so that
+    /// it can return `None` if `self` doesn't contain a `BorrowedHandle`.
+    ///
+    /// [`AsHandle::as_handle`]: std::os::windows::io::AsHandle::as_handle
+    #[inline]
+    #[must_use]
+    pub fn as_handle(&self) -> Option<BorrowedHandle> {
+        unsafe {
+            match self.raw.0 {
+                RawEnum::Handle(handle) => Some(BorrowedHandle::borrow_raw_handle(handle)),
+                RawEnum::Socket(_) => None,
+                RawEnum::Stdio(ref stdio) => {
+                    Some(BorrowedHandle::borrow_raw_handle(stdio.as_raw_handle()))
+                }
+            }
+        }
+    }
+
+    /// Like [`AsSocket::as_socket`], but returns an `Option` so that
+    /// it can return `None` if `self` doesn't contain a `BorrowedSocket`.
+    ///
+    /// [`AsSocket::as_socket`]: std::os::windows::io::AsSocket::as_socket
+    #[inline]
+    #[must_use]
+    pub fn as_socket(&self) -> Option<BorrowedSocket> {
+        unsafe {
+            match self.raw.0 {
+                RawEnum::Handle(_) => None,
+                RawEnum::Socket(socket) => Some(BorrowedSocket::borrow_raw_socket(socket)),
+                RawEnum::Stdio(_) => None,
+            }
         }
     }
 }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -67,7 +67,15 @@ impl Stream {
 
     fn use_file<Filelike: io_lifetimes::AsFilelike>(_filelike: &mut Filelike) {}
 
-    fn use_grip<Grip: io_extras::grip::AsGrip>(_grip: &mut Grip) {}
+    fn use_grip<Grip: io_extras::grip::AsGrip>(grip: &mut Grip) {
+        #[cfg(windows)]
+        assert_ne!(
+            grip.as_handle_or_socket().as_handle().is_some(),
+            grip.as_handle_or_socket().as_socket().is_some()
+        );
+        #[cfg(not(windows))]
+        let _ = grip.as_fd();
+    }
 
     fn from_socket<Socketlike: io_lifetimes::IntoSocketlike>(_socketlike: Socketlike) {}
 


### PR DESCRIPTION
Add ways to extract just the handle or socket from a owned or borrowed
handle-or-socket type.
