### PR TITLE
Update to the io-lifetimes `impl AsFd for &T` support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/sunfishcode/io-extras"
 exclude = ["/.github"]
 
 [dependencies]
-io-lifetimes = { version = "0.5.1", default-features = false }
+io-lifetimes = { version = "0.5.2", default-features = false }
 
 # Optionally depend on async-std to implement traits for its types.
 #

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -63,11 +63,11 @@ fn read_write() {
 
 struct Stream {}
 impl Stream {
-    fn use_socket<Socketlike: io_lifetimes::AsSocketlike>(_socketlike: &mut Socketlike) {}
+    fn use_socket<Socketlike: io_lifetimes::AsSocketlike>(_socketlike: Socketlike) {}
 
-    fn use_file<Filelike: io_lifetimes::AsFilelike>(_filelike: &mut Filelike) {}
+    fn use_file<Filelike: io_lifetimes::AsFilelike>(_filelike: Filelike) {}
 
-    fn use_grip<Grip: io_extras::grip::AsGrip>(grip: &mut Grip) {
+    fn use_grip<Grip: io_extras::grip::AsGrip>(grip: Grip) {
         #[cfg(windows)]
         assert_ne!(
             grip.as_handle_or_socket().as_handle().is_some(),
@@ -86,10 +86,10 @@ impl Stream {
 
 #[test]
 fn likes() {
-    let _ = Stream::use_socket(&mut std::net::TcpListener::bind("127.0.0.1:0").unwrap());
-    let _ = Stream::use_file(&mut std::fs::File::open("Cargo.toml").unwrap());
-    let _ = Stream::use_grip(&mut std::net::TcpListener::bind("127.0.0.1:0").unwrap());
-    let _ = Stream::use_grip(&mut std::fs::File::open("Cargo.toml").unwrap());
+    let _ = Stream::use_socket(std::net::TcpListener::bind("127.0.0.1:0").unwrap());
+    let _ = Stream::use_file(std::fs::File::open("Cargo.toml").unwrap());
+    let _ = Stream::use_grip(std::net::TcpListener::bind("127.0.0.1:0").unwrap());
+    let _ = Stream::use_grip(std::fs::File::open("Cargo.toml").unwrap());
 
     let _ = Stream::from_socket(std::net::TcpListener::bind("127.0.0.1:0").unwrap());
     let _ = Stream::from_file(std::fs::File::open("Cargo.toml").unwrap());


### PR DESCRIPTION
Update to io-lifetimes 0.5.2 and `impl AsFd for &T` support added in
rust-lang/rust#93888 and sunfishcode/io-lifetimes#18.