### PR TITLE
Update to io-lifetimes 0.6.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/sunfishcode/io-extras"
 exclude = ["/.github"]
 
 [dependencies]
-io-lifetimes = { version = "0.5.2", default-features = false }
+io-lifetimes = { version = "0.6.0", default-features = false }
 
 # Optionally depend on async-std to implement traits for its types.
 #

--- a/src/grip.rs
+++ b/src/grip.rs
@@ -357,12 +357,12 @@ impl<T: FromRawHandleOrSocket> FromRawGrip for T {
 ///
 /// # Safety
 ///
-/// See the safety conditions for [`borrow_raw_fd`].
+/// See the safety conditions for [`borrow_raw`].
 ///
-/// [`borrow_raw_fd`]: https://doc.rust-lang.org/stable/std/os/unix/io/struct.BorrowedFd.html#method.borrow_raw_fd
+/// [`borrow_raw`]: https://doc.rust-lang.org/stable/std/os/unix/io/struct.BorrowedFd.html#method.borrow_raw
 #[cfg(not(windows))]
-pub unsafe fn borrow_raw_grip<'a>(grip: RawGrip) -> BorrowedGrip<'a> {
-    BorrowedFd::borrow_raw_fd(grip)
+pub unsafe fn borrow_raw<'a>(grip: RawGrip) -> BorrowedGrip<'a> {
+    BorrowedFd::borrow_raw(grip)
 }
 
 /// Portability abstraction over `BorrowedFd::from_raw_fd` and
@@ -370,12 +370,12 @@ pub unsafe fn borrow_raw_grip<'a>(grip: RawGrip) -> BorrowedGrip<'a> {
 ///
 /// # Safety
 ///
-/// See the safety conditions for [`borrow_raw_handle`], and
-/// [`borrow_raw_socket`].
+/// See the safety conditions for [`BorrowedHandle::borrow_raw`], and
+/// [`BorrowedSocket::borrow_raw`].
 ///
-/// [`borrow_raw_handle`]: https://doc.rust-lang.org/stable/std/os/windows/io/struct.BorrowedHandle.html#method.borrow_raw_handle
-/// [`borrow_raw_socket`]: https://doc.rust-lang.org/stable/std/os/windows/io/struct.BorrowedSocket.html#method.borrow_raw_socket
+/// [`BorrowedHandle::borrow_raw`]: https://doc.rust-lang.org/stable/std/os/windows/io/struct.BorrowedHandle.html#method.borrow_raw
+/// [`BorrowedSocket::borrow_raw`]: https://doc.rust-lang.org/stable/std/os/windows/io/struct.BorrowedSocket.html#method.borrow_raw
 #[cfg(windows)]
-pub unsafe fn borrow_raw_grip<'a>(grip: RawGrip) -> BorrowedGrip<'a> {
-    BorrowedHandleOrSocket::borrow_raw_handle_or_socket(grip)
+pub unsafe fn borrow_raw<'a>(grip: RawGrip) -> BorrowedGrip<'a> {
+    BorrowedHandleOrSocket::borrow_raw(grip)
 }

--- a/src/os/windows/traits.rs
+++ b/src/os/windows/traits.rs
@@ -50,9 +50,7 @@ pub trait FromHandleOrSocket {
 impl AsHandleOrSocket for OwnedHandleOrSocket {
     #[inline]
     fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
-        unsafe {
-            BorrowedHandleOrSocket::borrow_raw_handle_or_socket(self.as_raw_handle_or_socket())
-        }
+        unsafe { BorrowedHandleOrSocket::borrow_raw(self.as_raw_handle_or_socket()) }
     }
 }
 

--- a/src/os/windows/types.rs
+++ b/src/os/windows/types.rs
@@ -33,7 +33,7 @@ impl<'a> BorrowedHandleOrSocket<'a> {
     /// the returned `BorrowedHandleOrSocket`, and it must not be a null handle
     /// or an invalid socket.
     #[inline]
-    pub unsafe fn borrow_raw_handle_or_socket(raw: RawHandleOrSocket) -> Self {
+    pub unsafe fn borrow_raw(raw: RawHandleOrSocket) -> Self {
         match raw.0 {
             RawEnum::Handle(raw_handle) => assert!(!raw_handle.is_null()),
             RawEnum::Socket(raw_socket) => assert_ne!(raw_socket, INVALID_SOCKET as RawSocket),
@@ -72,10 +72,10 @@ impl<'a> BorrowedHandleOrSocket<'a> {
     pub fn as_handle(&self) -> Option<BorrowedHandle> {
         unsafe {
             match self.raw.0 {
-                RawEnum::Handle(handle) => Some(BorrowedHandle::borrow_raw_handle(handle)),
+                RawEnum::Handle(handle) => Some(BorrowedHandle::borrow_raw(handle)),
                 RawEnum::Socket(_) => None,
                 RawEnum::Stdio(ref stdio) => {
-                    Some(BorrowedHandle::borrow_raw_handle(stdio.as_raw_handle()))
+                    Some(BorrowedHandle::borrow_raw(stdio.as_raw_handle()))
                 }
             }
         }
@@ -91,7 +91,7 @@ impl<'a> BorrowedHandleOrSocket<'a> {
         unsafe {
             match self.raw.0 {
                 RawEnum::Handle(_) => None,
-                RawEnum::Socket(socket) => Some(BorrowedSocket::borrow_raw_socket(socket)),
+                RawEnum::Socket(socket) => Some(BorrowedSocket::borrow_raw(socket)),
                 RawEnum::Stdio(_) => None,
             }
         }
@@ -141,10 +141,10 @@ impl OwnedHandleOrSocket {
     pub fn as_handle(&self) -> Option<BorrowedHandle> {
         unsafe {
             match self.raw.0 {
-                RawEnum::Handle(handle) => Some(BorrowedHandle::borrow_raw_handle(handle)),
+                RawEnum::Handle(handle) => Some(BorrowedHandle::borrow_raw(handle)),
                 RawEnum::Socket(_) => None,
                 RawEnum::Stdio(ref stdio) => {
-                    Some(BorrowedHandle::borrow_raw_handle(stdio.as_raw_handle()))
+                    Some(BorrowedHandle::borrow_raw(stdio.as_raw_handle()))
                 }
             }
         }
@@ -160,7 +160,7 @@ impl OwnedHandleOrSocket {
         unsafe {
             match self.raw.0 {
                 RawEnum::Handle(_) => None,
-                RawEnum::Socket(socket) => Some(BorrowedSocket::borrow_raw_socket(socket)),
+                RawEnum::Socket(socket) => Some(BorrowedSocket::borrow_raw(socket)),
                 RawEnum::Stdio(_) => None,
             }
         }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -8,6 +8,8 @@ use io_lifetimes::views::FilelikeView;
 use std::fmt;
 use std::fs::File;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
+#[cfg(all(doc, not(windows)))]
+use std::net::TcpStream;
 #[cfg(windows)]
 use {
     crate::os::windows::{

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -23,30 +23,22 @@ struct Stdio {}
 #[cfg(not(windows))]
 impl AsReadWriteFd for Stdio {
     fn as_read_fd(&self) -> BorrowedFd<'_> {
-        unsafe { BorrowedFd::borrow_raw_fd(std::io::stdin().as_raw_fd()) }
+        unsafe { BorrowedFd::borrow_raw(std::io::stdin().as_raw_fd()) }
     }
 
     fn as_write_fd(&self) -> BorrowedFd<'_> {
-        unsafe { BorrowedFd::borrow_raw_fd(std::io::stdout().as_raw_fd()) }
+        unsafe { BorrowedFd::borrow_raw(std::io::stdout().as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
 impl AsReadWriteHandleOrSocket for Stdio {
     fn as_read_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
-        unsafe {
-            BorrowedHandleOrSocket::borrow_raw_handle_or_socket(
-                std::io::stdin().as_raw_handle_or_socket(),
-            )
-        }
+        unsafe { BorrowedHandleOrSocket::borrow_raw(std::io::stdin().as_raw_handle_or_socket()) }
     }
 
     fn as_write_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
-        unsafe {
-            BorrowedHandleOrSocket::borrow_raw_handle_or_socket(
-                std::io::stdout().as_raw_handle_or_socket(),
-            )
-        }
+        unsafe { BorrowedHandleOrSocket::borrow_raw(std::io::stdout().as_raw_handle_or_socket()) }
     }
 }
 


### PR DESCRIPTION
The main change here is the change from `borrow_raw_fd` to `borrow_raw`.