### PR TITLE
Add `#![cfg_attr(io_lifetimes_use_std, feature(io_safety))]` to a test.

### DIFF
--- a/tests/api.rs
+++ b/tests/api.rs
@@ -3,6 +3,7 @@
 //! demonstrates the API of this crate.
 
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
+#![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 #![allow(unstable_name_collisions)]
 
 use io_extras::grip::{AsGrip, AsRawGrip};


### PR DESCRIPTION
This allows running the tests in io_lifetimes_use_std mode.