### PR TITLE
Add {Owned,Borrowed}{Readable,Writeable} types.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,3 +44,5 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     - run: cargo test --workspace --all-features
+      env:
+        RUST_BACKTRACE: 1

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -1,5 +1,6 @@
 //! `BorrowedReadable` and `BorrowedWriteable`.
 
+use crate::grip::{AsRawGrip, BorrowedGrip, FromRawGrip};
 #[cfg(windows)]
 use crate::os::windows::{AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket};
 use crate::raw::{RawReadable, RawWriteable};
@@ -43,6 +44,30 @@ pub struct BorrowedReadable<'a> {
 pub struct BorrowedWriteable<'a> {
     raw: RawWriteable,
     _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> BorrowedReadable<'a> {
+    /// Create a `BorrowedReadable` that can read from a `BorrowedGrip`.
+    #[must_use]
+    #[inline]
+    pub fn borrow(grip: BorrowedGrip<'a>) -> Self {
+        Self {
+            raw: unsafe { RawReadable::from_raw_grip(grip.as_raw_grip()) },
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a> BorrowedWriteable<'a> {
+    /// Create a `BorrowedReadable` that can write to a `BorrowedGrip`.
+    #[must_use]
+    #[inline]
+    pub fn borrow(grip: BorrowedGrip<'a>) -> Self {
+        Self {
+            raw: unsafe { RawWriteable::from_raw_grip(grip.as_raw_grip()) },
+            _phantom: PhantomData,
+        }
+    }
 }
 
 /// `BorrowedReadable` borrows its handle.

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -1,0 +1,276 @@
+//! `BorrowedReadable` and `BorrowedWriteable`.
+
+#[cfg(windows)]
+use crate::os::windows::{AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket};
+use crate::raw::{RawReadable, RawWriteable};
+#[cfg(not(windows))]
+use io_lifetimes::{AsFd, BorrowedFd};
+use std::fmt;
+use std::io::{self, IoSlice, IoSliceMut, Read, Write};
+use std::marker::PhantomData;
+#[cfg(all(doc, not(windows)))]
+use std::net::TcpStream;
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+#[cfg(target_os = "wasi")]
+use std::os::wasi::io::AsRawFd;
+
+/// An owning I/O handle that implements [`Read`].
+///
+/// This doesn't implement `Into*` or `From*` traits.
+///
+/// # Platform-specific behavior
+///
+/// On Posix-ish platforms, this reads from the handle as if it were a
+/// [`File`]. On Windows, this reads from a file-like handle as if it were a
+/// [`File`], and from a socket-like handle as if it were a [`TcpStream`].
+#[repr(transparent)]
+pub struct BorrowedReadable<'a> {
+    raw: RawReadable,
+    _phantom: PhantomData<&'a ()>,
+}
+
+/// An owning I/O handle that implements [`Write`].
+///
+/// This doesn't implement `Into*` or `From*` traits.
+///
+/// # Platform-specific behavior
+///
+/// On Posix-ish platforms, this writes to the handle as if it were a
+/// [`File`]. On Windows, this writes to a file-like handle as if it were a
+/// [`File`], and to a socket-like handle as if it were a [`TcpStream`].
+#[repr(transparent)]
+pub struct BorrowedWriteable<'a> {
+    raw: RawWriteable,
+    _phantom: PhantomData<&'a ()>,
+}
+
+/// `BorrowedReadable` borrows its handle.
+#[cfg(not(windows))]
+impl<'a> AsFd for BorrowedReadable<'a> {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.raw.as_raw_fd()) }
+    }
+}
+
+/// `BorrowedWriteable` borrows its handle.
+#[cfg(not(windows))]
+impl<'a> AsFd for BorrowedWriteable<'a> {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.raw.as_raw_fd()) }
+    }
+}
+
+// Windows implementations.
+
+/// `BorrowedReadable` borrows its handle.
+#[cfg(windows)]
+impl<'a> AsHandleOrSocket for BorrowedReadable<'a> {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        unsafe { BorrowedHandleOrSocket::borrow_raw(self.raw.as_raw_handle_or_socket()) }
+    }
+}
+
+/// `BorrowedWriteable` borrows its handle.
+#[cfg(windows)]
+impl<'a> AsHandleOrSocket for BorrowedWriteable<'a> {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        unsafe { BorrowedHandleOrSocket::borrow_raw(self.raw.as_raw_handle_or_socket()) }
+    }
+}
+
+#[cfg(not(windows))]
+impl<'a> Read for BorrowedReadable<'a> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.raw.read(buf)
+    }
+
+    #[inline]
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        self.raw.read_vectored(bufs)
+    }
+
+    #[cfg(can_vector)]
+    #[inline]
+    fn is_read_vectored(&self) -> bool {
+        self.raw.is_read_vectored()
+    }
+
+    #[inline]
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.raw.read_to_end(buf)
+    }
+
+    #[inline]
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        self.raw.read_to_string(buf)
+    }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.raw.read_exact(buf)
+    }
+}
+
+#[cfg(windows)]
+impl<'a> Read for BorrowedReadable<'a> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.raw.read(buf)
+    }
+
+    #[inline]
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        self.raw.read_vectored(bufs)
+    }
+
+    #[cfg(can_vector)]
+    #[inline]
+    fn is_read_vectored(&self) -> bool {
+        self.raw.is_read_vectored()
+    }
+
+    #[inline]
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.raw.read_to_end(buf)
+    }
+
+    #[inline]
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        self.raw.read_to_string(buf)
+    }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.raw.read_exact(buf)
+    }
+}
+
+#[cfg(not(windows))]
+impl<'a> Write for BorrowedWriteable<'a> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.raw.write(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.raw.flush()
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.raw.write_vectored(bufs)
+    }
+
+    #[cfg(can_vector)]
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        self.raw.is_write_vectored()
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.raw.write_all(buf)
+    }
+
+    #[cfg(write_all_vectored)]
+    #[inline]
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.raw.write_all_vectored(bufs)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.raw.write_fmt(fmt)
+    }
+}
+
+#[cfg(windows)]
+impl<'a> Write for BorrowedWriteable<'a> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.raw.write(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.raw.flush()
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.raw.write_vectored(bufs)
+    }
+
+    #[cfg(can_vector)]
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        self.raw.is_write_vectored()
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.raw.write_all(buf)
+    }
+
+    #[cfg(write_all_vectored)]
+    #[inline]
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.raw.write_all_vectored(bufs)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.raw.write_fmt(fmt)
+    }
+}
+
+#[cfg(not(windows))]
+impl<'a> fmt::Debug for BorrowedReadable<'a> {
+    #[allow(clippy::missing_inline_in_public_items)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Just print the raw fd number.
+        f.debug_struct("BorrowedReadable")
+            .field("fd", &self.raw)
+            .finish()
+    }
+}
+
+#[cfg(windows)]
+impl<'a> fmt::Debug for BorrowedReadable<'a> {
+    #[allow(clippy::missing_inline_in_public_items)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Just print the raw handle or socket.
+        f.debug_struct("BorrowedReadable")
+            .field("handle_or_socket", &self.raw)
+            .finish()
+    }
+}
+
+#[cfg(not(windows))]
+impl<'a> fmt::Debug for BorrowedWriteable<'a> {
+    #[allow(clippy::missing_inline_in_public_items)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Just print the raw fd number.
+        f.debug_struct("BorrowedWriteable")
+            .field("fd", &self.raw)
+            .finish()
+    }
+}
+
+#[cfg(windows)]
+impl<'a> fmt::Debug for BorrowedWriteable<'a> {
+    #[allow(clippy::missing_inline_in_public_items)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Just print the raw handle or socket.
+        f.debug_struct("BorrowedWriteable")
+            .field("handle_or_socket", &self.raw)
+            .finish()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,9 @@
 //!   `HandleOrSocket` types and traits and their corresponding non-Windows `Fd`
 //!   types and traits.
 //!
-//! - `RawReadable` and `RawWritable`, which adapt a raw `Fd`/`Handle` to
-//!   implement the `Read` and `Write` traits, respectively.
+//! - `OwnedReadable`, `OwnedWriteable`, `BorrowedReadable`,
+//!   `BorrowedWriteable`, `RawReadable` and `RawWriteable`, which adapt a raw
+//!   `Fd`/`Handle` to implement the `Read` and `Write` traits, respectively.
 //!
 //! - `ReadWrite` traits, and supporting types, which provide abstractions over
 //!   types with one or two I/O resources, for reading and for writing.
@@ -19,7 +20,9 @@
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 
+pub mod borrowed;
 pub mod grip;
 pub mod os;
+pub mod owned;
 pub mod raw;
 pub mod read_write;

--- a/src/os/windows/types.rs
+++ b/src/os/windows/types.rs
@@ -7,6 +7,7 @@ use super::{
 use io_lifetimes::{BorrowedHandle, BorrowedSocket, OwnedHandle, OwnedSocket};
 use std::fmt;
 use std::marker::PhantomData;
+use std::mem::forget;
 use std::os::windows::io::{
     AsRawHandle, AsRawSocket, FromRawHandle, FromRawSocket, IntoRawHandle, RawSocket,
 };
@@ -171,7 +172,9 @@ impl AsRawHandleOrSocket for BorrowedHandleOrSocket<'_> {
 impl IntoRawHandleOrSocket for OwnedHandleOrSocket {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
-        self.raw
+        let raw = self.raw;
+        forget(self);
+        raw
     }
 }
 

--- a/src/os/windows/types.rs
+++ b/src/os/windows/types.rs
@@ -101,23 +101,6 @@ impl<'a> BorrowedHandleOrSocket<'a> {
 }
 
 impl OwnedHandleOrSocket {
-    /// Return an `OwnedHandleOrSocket` holding the given raw handle or socket.
-    ///
-    /// # Safety
-    ///
-    /// The resource pointed to by `raw` must remain open for the duration of
-    /// the returned `OwnedHandleOrSocket`, and it must not be a null handle
-    /// or an invalid socket.
-    #[inline]
-    pub unsafe fn acquire_raw_handle_or_socket(raw: RawHandleOrSocket) -> Self {
-        match raw.0 {
-            RawEnum::Handle(raw_handle) => assert!(!raw_handle.is_null()),
-            RawEnum::Socket(raw_socket) => assert_ne!(raw_socket, INVALID_SOCKET as RawSocket),
-            RawEnum::Stdio(_) => (),
-        }
-        Self { raw }
-    }
-
     /// Construct a new `OwnedHandleOrSocket` from an `OwnedHandle`.
     #[inline]
     pub fn from_handle(handle: OwnedHandle) -> Self {
@@ -193,6 +176,11 @@ impl IntoRawHandleOrSocket for OwnedHandleOrSocket {
 impl FromRawHandleOrSocket for OwnedHandleOrSocket {
     #[inline]
     unsafe fn from_raw_handle_or_socket(raw: RawHandleOrSocket) -> Self {
+        match raw.0 {
+            RawEnum::Handle(raw_handle) => assert!(!raw_handle.is_null()),
+            RawEnum::Socket(raw_socket) => assert_ne!(raw_socket, INVALID_SOCKET as RawSocket),
+            RawEnum::Stdio(_) => (),
+        }
         Self { raw }
     }
 }

--- a/src/os/windows/types.rs
+++ b/src/os/windows/types.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::mem::forget;
 use std::os::windows::io::{
-    AsRawHandle, AsRawSocket, FromRawHandle, FromRawSocket, IntoRawHandle, RawSocket,
+    AsRawHandle, AsRawSocket, FromRawHandle, FromRawSocket, IntoRawHandle, IntoRawSocket, RawSocket,
 };
 use winapi::um::winsock2::INVALID_SOCKET;
 
@@ -116,7 +116,7 @@ impl OwnedHandleOrSocket {
     #[inline]
     pub fn from_socket(socket: OwnedSocket) -> Self {
         Self {
-            raw: RawHandleOrSocket(RawEnum::Socket(socket.as_raw_socket())),
+            raw: RawHandleOrSocket(RawEnum::Socket(socket.into_raw_socket())),
         }
     }
 

--- a/src/os/windows/types.rs
+++ b/src/os/windows/types.rs
@@ -7,7 +7,9 @@ use super::{
 use io_lifetimes::{BorrowedHandle, BorrowedSocket, OwnedHandle, OwnedSocket};
 use std::fmt;
 use std::marker::PhantomData;
-use std::os::windows::io::{AsRawHandle, AsRawSocket, FromRawHandle, FromRawSocket, RawSocket};
+use std::os::windows::io::{
+    AsRawHandle, AsRawSocket, FromRawHandle, FromRawSocket, IntoRawHandle, RawSocket,
+};
 use winapi::um::winsock2::INVALID_SOCKET;
 
 /// `HandleOrSocket` variant of io-lifetimes'
@@ -105,7 +107,7 @@ impl OwnedHandleOrSocket {
     #[inline]
     pub fn from_handle(handle: OwnedHandle) -> Self {
         Self {
-            raw: RawHandleOrSocket(RawEnum::Handle(handle.as_raw_handle())),
+            raw: RawHandleOrSocket(RawEnum::Handle(handle.into_raw_handle())),
         }
     }
 

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -1,0 +1,397 @@
+//! `OwnedReadable` and `OwnedWriteable`.
+
+use crate::grip::{AsRawGrip, FromRawGrip, OwnedGrip};
+use crate::raw::{RawReadable, RawWriteable};
+#[cfg(not(windows))]
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use std::fmt;
+use std::io::{self, IoSlice, IoSliceMut, Read, Write};
+#[cfg(all(doc, not(windows)))]
+use std::net::TcpStream;
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
+#[cfg(target_os = "wasi")]
+use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd};
+#[cfg(windows)]
+use {
+    crate::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, FromHandleOrSocket,
+        FromRawHandleOrSocket, IntoHandleOrSocket, IntoRawHandleOrSocket, OwnedHandleOrSocket,
+    },
+    io_lifetimes::{FromHandle, OwnedHandle},
+    std::os::windows::io::{FromRawHandle, IntoRawHandle},
+};
+
+/// An owning I/O handle that implements [`Read`].
+///
+/// This doesn't implement `Into*` or `From*` traits.
+///
+/// # Platform-specific behavior
+///
+/// On Posix-ish platforms, this reads from the handle as if it were a
+/// [`File`]. On Windows, this reads from a file-like handle as if it were a
+/// [`File`], and from a socket-like handle as if it were a [`TcpStream`].
+#[repr(transparent)]
+pub struct OwnedReadable(RawReadable);
+
+/// An owning I/O handle that implements [`Write`].
+///
+/// This doesn't implement `Into*` or `From*` traits.
+///
+/// # Platform-specific behavior
+///
+/// On Posix-ish platforms, this writes to the handle as if it were a
+/// [`File`]. On Windows, this writes to a file-like handle as if it were a
+/// [`File`], and to a socket-like handle as if it were a [`TcpStream`].
+#[repr(transparent)]
+pub struct OwnedWriteable(RawWriteable);
+
+/// `OwnedReadable` owns its handle.
+#[cfg(not(windows))]
+impl AsFd for OwnedReadable {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.0.as_raw_fd()) }
+    }
+}
+
+/// `OwnedReadable` owns its handle.
+#[cfg(not(windows))]
+impl IntoFd for OwnedReadable {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        unsafe { OwnedFd::from_raw_fd(self.0.into_raw_fd()) }
+    }
+}
+
+/// `OwnedReadable` owns its handle.
+#[cfg(not(windows))]
+impl FromFd for OwnedReadable {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        unsafe { Self(RawReadable::from_raw_fd(fd.into_raw_fd())) }
+    }
+}
+
+/// `OwnedWriteable` owns its handle.
+#[cfg(not(windows))]
+impl AsFd for OwnedWriteable {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.0.as_raw_fd()) }
+    }
+}
+
+/// `OwnedWriteable` owns its handle.
+#[cfg(not(windows))]
+impl IntoFd for OwnedWriteable {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        unsafe { OwnedFd::from_raw_fd(self.0.as_raw_fd()) }
+    }
+}
+
+/// `OwnedWriteable` owns its handle.
+#[cfg(not(windows))]
+impl FromFd for OwnedWriteable {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        unsafe { Self(RawWriteable::from_raw_fd(fd.into_raw_fd())) }
+    }
+}
+
+// Windows implementations.
+
+/// `OwnedReadable` owns its handle.
+#[cfg(windows)]
+impl AsHandleOrSocket for OwnedReadable {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        unsafe { BorrowedHandleOrSocket::borrow_raw(self.0.as_raw_handle_or_socket()) }
+    }
+}
+
+/// `OwnedReadable` owns its handle.
+#[cfg(windows)]
+impl IntoHandleOrSocket for OwnedReadable {
+    #[inline]
+    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
+        unsafe {
+            OwnedHandleOrSocket::acquire_raw_handle_or_socket(self.0.into_raw_handle_or_socket())
+        }
+    }
+}
+
+/// `OwnedReadable` owns its handle.
+#[cfg(windows)]
+impl FromHandleOrSocket for OwnedReadable {
+    #[inline]
+    fn from_handle_or_socket(handle_or_socket: OwnedHandleOrSocket) -> Self {
+        unsafe {
+            Self(RawReadable::from_raw_handle_or_socket(
+                handle_or_socket.into_raw_handle_or_socket(),
+            ))
+        }
+    }
+}
+
+/// `OwnedReadable` owns its handle.
+#[cfg(windows)]
+impl FromHandle for OwnedReadable {
+    #[inline]
+    fn from_handle(handle: OwnedHandle) -> Self {
+        unsafe { Self(RawReadable::from_raw_handle(handle.into_raw_handle())) }
+    }
+}
+
+/// `OwnedWriteable` owns its handle.
+#[cfg(windows)]
+impl AsHandleOrSocket for OwnedWriteable {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        unsafe { BorrowedHandleOrSocket::borrow_raw(self.0.as_raw_handle_or_socket()) }
+    }
+}
+
+/// `OwnedWriteable` owns its handle.
+#[cfg(windows)]
+impl IntoHandleOrSocket for OwnedWriteable {
+    #[inline]
+    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
+        unsafe {
+            OwnedHandleOrSocket::from_raw_handle_or_socket(self.0.into_raw_handle_or_socket())
+        }
+    }
+}
+
+/// `OwnedWriteable` owns its handle.
+#[cfg(windows)]
+impl FromHandleOrSocket for OwnedWriteable {
+    #[inline]
+    fn from_handle_or_socket(handle_or_socket: OwnedHandleOrSocket) -> Self {
+        unsafe {
+            Self(RawWriteable::from_raw_handle_or_socket(
+                handle_or_socket.into_raw_handle_or_socket(),
+            ))
+        }
+    }
+}
+
+/// `OwnedWriteable` owns its handle.
+#[cfg(windows)]
+impl FromHandle for OwnedWriteable {
+    #[inline]
+    fn from_handle(handle: OwnedHandle) -> Self {
+        unsafe { Self(RawWriteable::from_raw_handle(handle.into_raw_handle())) }
+    }
+}
+
+#[cfg(not(windows))]
+impl Read for OwnedReadable {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+
+    #[inline]
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        self.0.read_vectored(bufs)
+    }
+
+    #[cfg(can_vector)]
+    #[inline]
+    fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
+    }
+
+    #[inline]
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.0.read_to_end(buf)
+    }
+
+    #[inline]
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        self.0.read_to_string(buf)
+    }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.0.read_exact(buf)
+    }
+}
+
+#[cfg(windows)]
+impl Read for OwnedReadable {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+
+    #[inline]
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        self.0.read_vectored(bufs)
+    }
+
+    #[cfg(can_vector)]
+    #[inline]
+    fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
+    }
+
+    #[inline]
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.0.read_to_end(buf)
+    }
+
+    #[inline]
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        self.0.read_to_string(buf)
+    }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.0.read_exact(buf)
+    }
+}
+
+#[cfg(not(windows))]
+impl Write for OwnedWriteable {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.0.write_vectored(bufs)
+    }
+
+    #[cfg(can_vector)]
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0.write_all(buf)
+    }
+
+    #[cfg(write_all_vectored)]
+    #[inline]
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.0.write_all_vectored(bufs)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.0.write_fmt(fmt)
+    }
+}
+
+#[cfg(windows)]
+impl Write for OwnedWriteable {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.0.write_vectored(bufs)
+    }
+
+    #[cfg(can_vector)]
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0.write_all(buf)
+    }
+
+    #[cfg(write_all_vectored)]
+    #[inline]
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.0.write_all_vectored(bufs)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.0.write_fmt(fmt)
+    }
+}
+
+impl Drop for OwnedReadable {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            let _owned = OwnedGrip::from_raw_grip(self.0.as_raw_grip());
+        }
+    }
+}
+
+impl Drop for OwnedWriteable {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            let _owned = OwnedGrip::from_raw_grip(self.0.as_raw_grip());
+        }
+    }
+}
+
+#[cfg(not(windows))]
+impl fmt::Debug for OwnedReadable {
+    #[allow(clippy::missing_inline_in_public_items)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Just print the raw fd number.
+        f.debug_struct("OwnedReadable")
+            .field("fd", &self.0)
+            .finish()
+    }
+}
+
+#[cfg(windows)]
+impl fmt::Debug for OwnedReadable {
+    #[allow(clippy::missing_inline_in_public_items)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Just print the raw handle or socket.
+        f.debug_struct("OwnedReadable")
+            .field("handle_or_socket", &self.0)
+            .finish()
+    }
+}
+
+#[cfg(not(windows))]
+impl fmt::Debug for OwnedWriteable {
+    #[allow(clippy::missing_inline_in_public_items)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Just print the raw fd number.
+        f.debug_struct("OwnedWriteable")
+            .field("fd", &self.0)
+            .finish()
+    }
+}
+
+#[cfg(windows)]
+impl fmt::Debug for OwnedWriteable {
+    #[allow(clippy::missing_inline_in_public_items)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Just print the raw handle or socket.
+        f.debug_struct("OwnedWriteable")
+            .field("handle_or_socket", &self.0)
+            .finish()
+    }
+}

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -117,7 +117,7 @@ impl IntoHandleOrSocket for OwnedReadable {
     #[inline]
     fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
         unsafe {
-            OwnedHandleOrSocket::acquire_raw_handle_or_socket(self.0.into_raw_handle_or_socket())
+            OwnedHandleOrSocket::from_raw_handle_or_socket(self.0.into_raw_handle_or_socket())
         }
     }
 }

--- a/tests/os_pipe.rs
+++ b/tests/os_pipe.rs
@@ -102,7 +102,7 @@ fn os_pipe_borrowed_readable() -> io::Result<()> {
 
 #[test]
 #[cfg_attr(miri, ignore)] // pipe I/O calls foreign functions
-fn tcp_stream_owned_readable() -> io::Result<()> {
+fn os_pipe_owned_readable() -> io::Result<()> {
     // Obtain a `OwnedReadable` and use it to read.
     let stream = write_to_pipe()?;
     let mut buf = String::new();


### PR DESCRIPTION
Add {Owned,Borrowed}{Readable,Writeable} types.
    
These are like the existing Raw{Readable,Writeable}, but own and borrow
their handles, respectively.
    
This also fixes missing `IntoRawHandleOrSocket`, `FromRawHandleOrSocket`
and `Drop` on `OwnedHandleOrSocket`.
