### PR TITLE
Exclude tests and examples from the crates.io package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 keywords = ["api", "io", "stream"]
 categories = ["os", "rust-patterns"]
 repository = "https://github.com/sunfishcode/io-extras"
-exclude = ["/.github"]
+include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 
 [dependencies]
 io-lifetimes = { version = "0.7.0", default-features = false }


### PR DESCRIPTION
This shrinks the generated package size from 34999 bytes to 32902 bytes.