### PR TITLE
Switch from `FromFd` to `From<OwnedFd>` in the grip code.

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -8,5 +8,5 @@ inputs:
     default: 'stable'
 
 runs:
-  using: node12
+  using: node16
   main: 'main.js'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, nightly, windows]
+        build: [msrv, stable, nightly, windows]
         include:
+          - build: msrv
+            os: ubuntu-latest
+            rust: 1.58
           - build: stable
             os: ubuntu-latest
             rust: stable
@@ -46,3 +49,29 @@ jobs:
     - run: cargo test --workspace --all-features
       env:
         RUST_BACKTRACE: 1
+
+  check-msrv:
+    name: Check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [1.58]
+        include:
+          - build: 1.58
+            os: ubuntu-latest
+            rust: 1.58
+
+    env:
+      # -D warnings is commented out in our install-rust action; re-add it here.
+      RUSTFLAGS: -D warnings
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: ${{ matrix.rust }}
+
+    - run: rustup target add x86_64-apple-darwin
+    - run: cargo check --workspace --release -vv
+    - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [msrv, stable, nightly, windows]
+        build: [stable, nightly, windows]
         include:
-          - build: msrv
-            os: ubuntu-latest
-            rust: 1.58
           - build: stable
             os: ubuntu-latest
             rust: stable
@@ -48,6 +45,30 @@ jobs:
         toolchain: ${{ matrix.rust }}
     # Don't use --all-features because some of the features depend on trait
     # impls that aren't available yet.
-    - run: cargo test --workspace --features=os_pipe
+    - run: cargo test --workspace  --features=os_pipe
+      env:
+        RUST_BACKTRACE: 1
+
+  test_msrv:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [msrv]
+        include:
+          - build: msrv
+            os: ubuntu-latest
+            rust: 1.58
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: ${{ matrix.rust }}
+    # Don't use --all-features because some of the features have dependencies
+    # that don't work on newer Rust versions.
+    - run: cargo test --workspace
       env:
         RUST_BACKTRACE: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, nightly, windows]
+        build: [msrv, stable, nightly, windows]
         include:
+          - build: msrv
+            os: ubuntu-latest
+            rust: 1.58
           - build: stable
             os: ubuntu-latest
             rust: stable
@@ -43,30 +46,8 @@ jobs:
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-    - run: cargo test --workspace --all-features
-      env:
-        RUST_BACKTRACE: 1
-
-  test_msrv:
-    name: Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        build: [msrv]
-        include:
-          - build: msrv
-            os: ubuntu-latest
-            rust: 1.58
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: ./.github/actions/install-rust
-      with:
-        toolchain: ${{ matrix.rust }}
-    # Don't use --all-features because some of the features have dependencies
-    # that don't work on newer Rust versions.
+    # Don't use --all-features because some of the features depend on trait
+    # impls that aren't available yet.
     - run: cargo test --workspace --features=os_pipe
       env:
         RUST_BACKTRACE: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [msrv, stable, nightly, windows]
+        build: [stable, nightly, windows]
         include:
-          - build: msrv
-            os: ubuntu-latest
-            rust: 1.58
           - build: stable
             os: ubuntu-latest
             rust: stable
@@ -50,20 +47,17 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
-  check-msrv:
-    name: Check
+  test_msrv:
+    name: Test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [1.58]
+        build: [msrv]
         include:
-          - build: 1.58
+          - build: msrv
             os: ubuntu-latest
             rust: 1.58
 
-    env:
-      # -D warnings is commented out in our install-rust action; re-add it here.
-      RUSTFLAGS: -D warnings
     steps:
     - uses: actions/checkout@v2
       with:
@@ -71,7 +65,8 @@ jobs:
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
-
-    - run: rustup target add x86_64-apple-darwin
-    - run: cargo check --workspace --release -vv
-    - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin
+    # Don't use --all-features because some of the features have dependencies
+    # that don't work on newer Rust versions.
+    - run: cargo test --workspace --features=os_pipe
+      env:
+        RUST_BACKTRACE: 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ features = [
 ]
 
 [dev-dependencies]
-os_pipe = { version = "1.0.0" }
+os_pipe = "1.0.0"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ features = [
 ]
 
 [dev-dependencies]
-os_pipe = { version = "1.0.0", features = ["io_safety"] }
+os_pipe = { version = "1.0.0" }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ features = [
 ]
 
 [dev-dependencies]
-os_pipe = "1.0.0"
+os_pipe = { version = "1.0.0", features = ["io_safety"] }
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ This crate provides a few miscellaneous utilities related to I/O:
 
  - `ReadWrite` traits, and supporting types, which provide abstractions over
    types with one or two I/O resources, for reading and for writing.
+
+## Minimum Supported Rust Version (MSRV)
+
+This crate currently works on Rust 1.58.

--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ This crate provides a few miscellaneous utilities related to I/O:
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate currently works on Rust 1.58.
+This crate currently works on Rust 1.58, when default features are enabled.
+Some of the optional features have stricter requirements.

--- a/src/grip.rs
+++ b/src/grip.rs
@@ -11,7 +11,7 @@ use crate::os::windows::{
 #[cfg(not(windows))]
 use {
     crate::os::rustix::{AsRawFd, AsRawReadWriteFd, AsReadWriteFd, FromRawFd, IntoRawFd, RawFd},
-    io_lifetimes::{AsFd, BorrowedFd, FromFd, OwnedFd},
+    io_lifetimes::{AsFd, BorrowedFd, OwnedFd},
 };
 
 /// Portability abstraction over `BorrowedFd` and `BorrowedHandleOrSocket`.
@@ -92,15 +92,15 @@ pub trait IntoGrip: IntoHandleOrSocket {
     fn into_grip(self) -> OwnedGrip;
 }
 
-/// Portability abstraction over `FromFd` and
+/// Portability abstraction over `From<OwnedFd>` and
 /// `FromHandleOrSocket`.
 #[cfg(not(windows))]
-pub trait FromGrip: FromFd {
+pub trait FromGrip: From<OwnedFd> {
     /// Consume an `OwnedGrip` and convert into a `Self`.
     fn from_grip(owned_grip: OwnedGrip) -> Self;
 }
 
-/// Portability abstraction over `FromFd` and
+/// Portability abstraction over `From<OwnedFd>` and
 /// `FromHandleOrSocket`.
 #[cfg(windows)]
 pub trait FromGrip: FromHandleOrSocket {
@@ -254,7 +254,7 @@ pub trait IntoRawGrip: IntoRawHandleOrSocket {
     fn into_raw_grip(self) -> RawGrip;
 }
 
-/// Portability abstraction over `FromFd` and
+/// Portability abstraction over `From<OwnedFd>` and
 /// `FromHandleOrSocket`.
 #[cfg(not(windows))]
 pub trait FromRawGrip: FromRawFd {
@@ -266,7 +266,7 @@ pub trait FromRawGrip: FromRawFd {
     unsafe fn from_raw_grip(raw_grip: RawGrip) -> Self;
 }
 
-/// Portability abstraction over `FromFd` and
+/// Portability abstraction over `From<OwnedFd>` and
 /// `FromHandleOrSocket`.
 #[cfg(windows)]
 pub trait FromRawGrip: FromRawHandleOrSocket {

--- a/src/grip.rs
+++ b/src/grip.rs
@@ -5,8 +5,8 @@
 #[cfg(windows)]
 use crate::os::windows::{
     AsHandleOrSocket, AsRawHandleOrSocket, AsRawReadWriteHandleOrSocket, AsReadWriteHandleOrSocket,
-    BorrowedHandleOrSocket, FromHandleOrSocket, FromRawHandleOrSocket, IntoHandleOrSocket,
-    IntoRawHandleOrSocket, OwnedHandleOrSocket, RawHandleOrSocket,
+    BorrowedHandleOrSocket, FromRawHandleOrSocket, IntoRawHandleOrSocket, OwnedHandleOrSocket,
+    RawHandleOrSocket,
 };
 #[cfg(not(windows))]
 use {
@@ -77,7 +77,7 @@ pub trait AsReadWriteGrip: AsReadWriteHandleOrSocket {
 }
 
 /// Portability abstraction over `Into<OwnedFd>` and
-/// `IntoHandleOrSocket`.
+/// `Into<OwnedHandleOrSocket>`.
 #[cfg(not(windows))]
 pub trait IntoGrip: Into<OwnedFd> {
     /// Consume `self` and convert into an `OwnedGrip`.
@@ -85,15 +85,15 @@ pub trait IntoGrip: Into<OwnedFd> {
 }
 
 /// Portability abstraction over `Into<OwnedFd>` and
-/// `IntoHandleOrSocket`.
+/// `Into<OwnedHandleOrSocket>`.
 #[cfg(windows)]
-pub trait IntoGrip: IntoHandleOrSocket {
+pub trait IntoGrip: Into<OwnedHandleOrSocket> {
     /// Consume `self` and convert into an `OwnedGrip`.
     fn into_grip(self) -> OwnedGrip;
 }
 
 /// Portability abstraction over `From<OwnedFd>` and
-/// `FromHandleOrSocket`.
+/// `From<OwnedHandleOrSocket>`.
 #[cfg(not(windows))]
 pub trait FromGrip: From<OwnedFd> {
     /// Consume an `OwnedGrip` and convert into a `Self`.
@@ -101,9 +101,9 @@ pub trait FromGrip: From<OwnedFd> {
 }
 
 /// Portability abstraction over `From<OwnedFd>` and
-/// `FromHandleOrSocket`.
+/// `From<OwnedHandleOrSocket>`.
 #[cfg(windows)]
-pub trait FromGrip: FromHandleOrSocket {
+pub trait FromGrip: From<OwnedHandleOrSocket> {
     /// Consume an `OwnedGrip` and convert into a `Self`.
     fn from_grip(owned_grip: OwnedGrip) -> Self;
 }
@@ -159,10 +159,10 @@ impl<T: Into<OwnedFd>> IntoGrip for T {
 }
 
 #[cfg(windows)]
-impl<T: IntoHandleOrSocket> IntoGrip for T {
+impl<T: Into<OwnedHandleOrSocket>> IntoGrip for T {
     #[inline]
     fn into_grip(self) -> OwnedGrip {
-        self.into_handle_or_socket()
+        self.into()
     }
 }
 
@@ -175,10 +175,10 @@ impl<T: From<OwnedFd>> FromGrip for T {
 }
 
 #[cfg(windows)]
-impl<T: FromHandleOrSocket> FromGrip for T {
+impl<T: From<OwnedHandleOrSocket>> FromGrip for T {
     #[inline]
     fn from_grip(owned_grip: OwnedGrip) -> Self {
-        Self::from_handle_or_socket(owned_grip)
+        Self::from(owned_grip)
     }
 }
 
@@ -255,7 +255,7 @@ pub trait IntoRawGrip: IntoRawHandleOrSocket {
 }
 
 /// Portability abstraction over `From<OwnedFd>` and
-/// `FromHandleOrSocket`.
+/// `From<OwnedHandleOrSocket>`.
 #[cfg(not(windows))]
 pub trait FromRawGrip: FromRawFd {
     /// Consume an `RawGrip` and convert into a `Self`.
@@ -267,7 +267,7 @@ pub trait FromRawGrip: FromRawFd {
 }
 
 /// Portability abstraction over `From<OwnedFd>` and
-/// `FromHandleOrSocket`.
+/// `From<OwnedHandleOrSocket>`.
 #[cfg(windows)]
 pub trait FromRawGrip: FromRawHandleOrSocket {
     /// Consume an `RawGrip` and convert into a `Self`.

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -22,7 +22,7 @@ mod traits;
 mod types;
 
 pub use crate::read_write::{AsRawReadWriteHandleOrSocket, AsReadWriteHandleOrSocket};
-pub use traits::{AsHandleOrSocket, FromHandleOrSocket, IntoHandleOrSocket};
+pub use traits::AsHandleOrSocket;
 pub use types::{BorrowedHandleOrSocket, OwnedHandleOrSocket};
 
 /// A Windows analog for the Posix-ish `AsRawFd` type. Unlike Posix-ish

--- a/src/os/windows/stdio.rs
+++ b/src/os/windows/stdio.rs
@@ -262,7 +262,7 @@ fn read_u16s(handle: RawHandle, buf: &mut [u16]) -> io::Result<usize> {
     // stream / user input (SUB). See #38274 and https://stackoverflow.com/questions/43836040/win-api-readconsole.
     const CTRL_Z: u16 = 0x1A;
     const CTRL_Z_MASK: u32 = 1 << CTRL_Z;
-    let mut input_control = CONSOLE_READCONSOLE_CONTROL {
+    let input_control = CONSOLE_READCONSOLE_CONTROL {
         nLength: std::mem::size_of::<CONSOLE_READCONSOLE_CONTROL>() as u32,
         nInitialChars: 0,
         dwCtrlWakeupMask: CTRL_Z_MASK,
@@ -281,7 +281,7 @@ fn read_u16s(handle: RawHandle, buf: &mut [u16]) -> io::Result<usize> {
             buf.as_mut_ptr().cast::<c_void>(),
             len,
             &mut amount,
-            &mut input_control,
+            &input_control,
         )
     } == 0_i32
     {

--- a/src/os/windows/traits.rs
+++ b/src/os/windows/traits.rs
@@ -1,4 +1,4 @@
-//! `HandleOrSocket` variants of `{As,Into}{Handle,Socket}`.
+//! `AsHandleOrSocket` and related `From` impls.
 
 use super::types::{BorrowedHandleOrSocket, OwnedHandleOrSocket};
 use super::AsRawHandleOrSocket;
@@ -14,35 +14,6 @@ pub trait AsHandleOrSocket {
     /// Like [`AsHandle::as_handle`] and [`AsSocket::as_socket`]
     /// but can return either type.
     fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_>;
-}
-
-/// Like [`IntoHandle`] and [`IntoSocket`], but implementable by types
-/// which can implement either one.
-pub trait IntoHandleOrSocket {
-    /// Like [`IntoHandle::into_handle`] and
-    /// [`IntoSocket::into_socket`] but can return either type.
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket;
-}
-
-/// Like [`FromHandle`] and [`FromSocket`], but implementable by types
-/// which can implement both.
-///
-/// Note: Don't implement this trait for types which can only implement one
-/// or the other, such that it would need to panic if passed the wrong form.
-///
-/// [`FromHandle`]: io_lifetimes::FromHandle
-/// [`FromSocket`]: io_lifetimes::FromSocket
-pub trait FromHandleOrSocket {
-    /// Like [`FromHandle::from_handle`] and
-    /// [`FromSocket::from_socket`] but can be passed either type.
-    ///
-    /// # Safety
-    ///
-    /// `handle_or_socket` must be valid and otherwise unowned.
-    ///
-    /// [`FromHandle::from_handle`]: io_lifetimes::FromHandle::from_handle
-    /// [`FromSocket::from_socket`]: io_lifetimes::FromSocket::from_socket
-    fn from_handle_or_socket(handle_or_socket: OwnedHandleOrSocket) -> Self;
 }
 
 impl AsHandleOrSocket for OwnedHandleOrSocket {
@@ -360,141 +331,141 @@ impl AsHandleOrSocket for mio::net::UdpSocket {
     }
 }
 
-impl IntoHandleOrSocket for File {
+impl From<File> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_handle(self.into())
+    fn from(file: File) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_handle(file.into())
     }
 }
 
-impl IntoHandleOrSocket for ChildStdin {
+impl From<ChildStdin> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_handle(self.into())
+    fn from(stdin: ChildStdin) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_handle(stdin.into())
     }
 }
 
-impl IntoHandleOrSocket for ChildStdout {
+impl From<ChildStdout> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_handle(self.into())
+    fn from(stdout: ChildStdout) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_handle(stdout.into())
     }
 }
 
-impl IntoHandleOrSocket for ChildStderr {
+impl From<ChildStderr> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_handle(self.into())
+    fn from(stderr: ChildStderr) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_handle(stderr.into())
     }
 }
 
-impl IntoHandleOrSocket for TcpStream {
+impl From<TcpStream> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_socket(self.into())
+    fn from(stream: TcpStream) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_socket(stream.into())
     }
 }
 
-impl IntoHandleOrSocket for TcpListener {
+impl From<TcpListener> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_socket(self.into())
+    fn from(listener: TcpListener) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_socket(listener.into())
     }
 }
 
-impl IntoHandleOrSocket for UdpSocket {
+impl From<UdpSocket> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_socket(self.into())
-    }
-}
-
-#[cfg(feature = "os_pipe")]
-#[cfg(not(io_lifetimes_use_std))] // TODO: Enable when we have impls for os_pipe
-impl IntoHandleOrSocket for os_pipe::PipeReader {
-    #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_handle(self.into())
+    fn from(socket: UdpSocket) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_socket(socket.into())
     }
 }
 
 #[cfg(feature = "os_pipe")]
 #[cfg(not(io_lifetimes_use_std))] // TODO: Enable when we have impls for os_pipe
-impl IntoHandleOrSocket for os_pipe::PipeWriter {
+impl From<os_pipe::PipeReader> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_handle(self.into())
+    fn from(reader: os_pipe::PipeReader) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_handle(reader.into())
+    }
+}
+
+#[cfg(feature = "os_pipe")]
+#[cfg(not(io_lifetimes_use_std))] // TODO: Enable when we have impls for os_pipe
+impl From<os_pipe::PipeWriter> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(writer: os_pipe::PipeReader) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_handle(writer.into())
     }
 }
 
 #[cfg(feature = "socket2")]
 #[cfg(not(io_lifetimes_use_std))] // TODO: Enable when we have impls for socket2
-impl IntoHandleOrSocket for socket2::Socket {
+impl From<socket2::Socket> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_socket(self.into())
+    fn from(socket: socket2::Socket) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_socket(socket.into())
     }
 }
 
 #[cfg(feature = "use_mio_net")]
 #[cfg(not(io_lifetimes_use_std))] // TODO: Enable when we have impls for mio
-impl IntoHandleOrSocket for mio::net::TcpStream {
+impl From<mio::net::TcpStream> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_socket(self.into())
+    fn from(stream: mio::net::TcpStream) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_socket(stream.into())
     }
 }
 
 #[cfg(feature = "use_mio_net")]
 #[cfg(not(io_lifetimes_use_std))] // TODO: Enable when we have impls for mio
-impl IntoHandleOrSocket for mio::net::TcpListener {
+impl From<mio::net::TcpListener> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_socket(self.into())
+    fn from(listener: mio::net::TcpListener) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_socket(listener.into())
     }
 }
 
 #[cfg(feature = "use_mio_net")]
 #[cfg(not(io_lifetimes_use_std))] // TODO: Enable when we have impls for mio
-impl IntoHandleOrSocket for mio::net::UdpSocket {
+impl From<mio::net::UdpSocket> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_socket(self.into())
+    fn from(socket: mio::net::UdpSocket) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_socket(socket.into())
     }
 }
 
 #[cfg(feature = "async-std")]
 #[cfg(not(io_lifetimes_use_std))] // TODO: Enable when we have impls for async_std
-impl IntoHandleOrSocket for async_std::fs::File {
+impl From<async_std::fs::File> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_handle(self.into())
+    fn from(file: async_std::fs::File) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_handle(file.into())
     }
 }
 
 #[cfg(feature = "async-std")]
 #[cfg(not(io_lifetimes_use_std))] // TODO: Enable when we have impls for async_std
-impl IntoHandleOrSocket for async_std::net::TcpStream {
+impl From<async_std::net::TcpStream> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_socket(self.into())
+    fn from(stream: async_std::net::TcpStream) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_socket(stream.into())
     }
 }
 
 #[cfg(feature = "async-std")]
 #[cfg(not(io_lifetimes_use_std))] // TODO: Enable when we have impls for async_std
-impl IntoHandleOrSocket for async_std::net::TcpListener {
+impl From<async_std::net::TcpListener> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_socket(self.into())
+    fn from(listener: async_std::net::TcpListener) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_socket(listener.into())
     }
 }
 
 #[cfg(feature = "async-std")]
 #[cfg(not(io_lifetimes_use_std))] // TODO: Enable when we have impls for async_std
-impl IntoHandleOrSocket for async_std::net::UdpSocket {
+impl From<async_std::net::UdpSocket> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
-        OwnedHandleOrSocket::from_socket(self.into())
+    fn from(socket: async_std::net::UdpSocket) -> OwnedHandleOrSocket {
+        OwnedHandleOrSocket::from_socket(socket.into())
     }
 }

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -15,8 +15,8 @@ use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd};
 #[cfg(windows)]
 use {
     crate::os::windows::{
-        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, FromHandleOrSocket,
-        FromRawHandleOrSocket, IntoHandleOrSocket, IntoRawHandleOrSocket, OwnedHandleOrSocket,
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, FromRawHandleOrSocket,
+        IntoRawHandleOrSocket, OwnedHandleOrSocket,
     },
     io_lifetimes::OwnedHandle,
     std::os::windows::io::{FromRawHandle, IntoRawHandle},
@@ -113,20 +113,20 @@ impl AsHandleOrSocket for OwnedReadable {
 
 /// `OwnedReadable` owns its handle.
 #[cfg(windows)]
-impl IntoHandleOrSocket for OwnedReadable {
+impl From<OwnedReadable> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
+    fn from(readable: OwnedReadable) -> OwnedHandleOrSocket {
         unsafe {
-            OwnedHandleOrSocket::from_raw_handle_or_socket(self.0.into_raw_handle_or_socket())
+            OwnedHandleOrSocket::from_raw_handle_or_socket(readable.0.into_raw_handle_or_socket())
         }
     }
 }
 
 /// `OwnedReadable` owns its handle.
 #[cfg(windows)]
-impl FromHandleOrSocket for OwnedReadable {
+impl From<OwnedHandleOrSocket> for OwnedReadable {
     #[inline]
-    fn from_handle_or_socket(handle_or_socket: OwnedHandleOrSocket) -> Self {
+    fn from(handle_or_socket: OwnedHandleOrSocket) -> Self {
         unsafe {
             Self(RawReadable::from_raw_handle_or_socket(
                 handle_or_socket.into_raw_handle_or_socket(),
@@ -155,20 +155,20 @@ impl AsHandleOrSocket for OwnedWriteable {
 
 /// `OwnedWriteable` owns its handle.
 #[cfg(windows)]
-impl IntoHandleOrSocket for OwnedWriteable {
+impl From<OwnedWriteable> for OwnedHandleOrSocket {
     #[inline]
-    fn into_handle_or_socket(self) -> OwnedHandleOrSocket {
+    fn from(writeable: OwnedWriteable) -> OwnedHandleOrSocket {
         unsafe {
-            OwnedHandleOrSocket::from_raw_handle_or_socket(self.0.into_raw_handle_or_socket())
+            OwnedHandleOrSocket::from_raw_handle_or_socket(writeable.0.into_raw_handle_or_socket())
         }
     }
 }
 
 /// `OwnedWriteable` owns its handle.
 #[cfg(windows)]
-impl FromHandleOrSocket for OwnedWriteable {
+impl From<OwnedHandleOrSocket> for OwnedWriteable {
     #[inline]
-    fn from_handle_or_socket(handle_or_socket: OwnedHandleOrSocket) -> Self {
+    fn from(handle_or_socket: OwnedHandleOrSocket) -> Self {
         unsafe {
             Self(RawWriteable::from_raw_handle_or_socket(
                 handle_or_socket.into_raw_handle_or_socket(),

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -59,8 +59,8 @@ impl AsFd for OwnedReadable {
 #[cfg(not(windows))]
 impl From<OwnedReadable> for OwnedFd {
     #[inline]
-    fn from(owned: OwnedReadable) -> OwnedFd {
-        unsafe { OwnedFd::from_raw_fd(owned.0.into_raw_fd()) }
+    fn from(owned: OwnedReadable) -> Self {
+        unsafe { Self::from_raw_fd(owned.0.into_raw_fd()) }
     }
 }
 
@@ -86,8 +86,8 @@ impl AsFd for OwnedWriteable {
 #[cfg(not(windows))]
 impl From<OwnedWriteable> for OwnedFd {
     #[inline]
-    fn from(owned: OwnedWriteable) -> OwnedFd {
-        unsafe { OwnedFd::from_raw_fd(owned.0.as_raw_fd()) }
+    fn from(owned: OwnedWriteable) -> Self {
+        unsafe { Self::from_raw_fd(owned.0.as_raw_fd()) }
     }
 }
 
@@ -115,7 +115,7 @@ impl AsHandleOrSocket for OwnedReadable {
 #[cfg(windows)]
 impl From<OwnedReadable> for OwnedHandleOrSocket {
     #[inline]
-    fn from(readable: OwnedReadable) -> OwnedHandleOrSocket {
+    fn from(readable: OwnedReadable) -> Self {
         unsafe {
             OwnedHandleOrSocket::from_raw_handle_or_socket(readable.0.into_raw_handle_or_socket())
         }
@@ -157,7 +157,7 @@ impl AsHandleOrSocket for OwnedWriteable {
 #[cfg(windows)]
 impl From<OwnedWriteable> for OwnedHandleOrSocket {
     #[inline]
-    fn from(writeable: OwnedWriteable) -> OwnedHandleOrSocket {
+    fn from(writeable: OwnedWriteable) -> Self {
         unsafe {
             OwnedHandleOrSocket::from_raw_handle_or_socket(writeable.0.into_raw_handle_or_socket())
         }


### PR DESCRIPTION
To match the switch to io-lifetimes 1.0, use `From<OwnedFd>` instead of `FromFd`. This fixes build errors on Rust 1.58.

Also, add testing and declare an MSRV on Rust 1.58.
