### PR TITLE
Refine the lifetimes of `as_*` return values.

### DIFF
--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -74,7 +74,7 @@ impl<'a> BorrowedWriteable<'a> {
 #[cfg(not(windows))]
 impl<'a> AsFd for BorrowedReadable<'a> {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(&self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw(self.raw.as_raw_fd()) }
     }
 }
@@ -83,7 +83,7 @@ impl<'a> AsFd for BorrowedReadable<'a> {
 #[cfg(not(windows))]
 impl<'a> AsFd for BorrowedWriteable<'a> {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(&self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw(self.raw.as_raw_fd()) }
     }
 }
@@ -94,7 +94,7 @@ impl<'a> AsFd for BorrowedWriteable<'a> {
 #[cfg(windows)]
 impl<'a> AsHandleOrSocket for BorrowedReadable<'a> {
     #[inline]
-    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'a> {
         unsafe { BorrowedHandleOrSocket::borrow_raw(self.raw.as_raw_handle_or_socket()) }
     }
 }
@@ -103,7 +103,7 @@ impl<'a> AsHandleOrSocket for BorrowedReadable<'a> {
 #[cfg(windows)]
 impl<'a> AsHandleOrSocket for BorrowedWriteable<'a> {
     #[inline]
-    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'a> {
         unsafe { BorrowedHandleOrSocket::borrow_raw(self.raw.as_raw_handle_or_socket()) }
     }
 }

--- a/src/os/windows/types.rs
+++ b/src/os/windows/types.rs
@@ -74,7 +74,7 @@ impl<'a> BorrowedHandleOrSocket<'a> {
     /// [`AsHandle::as_handle`]: std::os::windows::io::AsHandle::as_handle
     #[inline]
     #[must_use]
-    pub fn as_handle(&self) -> Option<BorrowedHandle> {
+    pub fn as_handle(&self) -> Option<BorrowedHandle<'a>> {
         unsafe {
             match self.raw.0 {
                 RawEnum::Handle(handle) => Some(BorrowedHandle::borrow_raw(handle)),
@@ -92,7 +92,7 @@ impl<'a> BorrowedHandleOrSocket<'a> {
     /// [`AsSocket::as_socket`]: std::os::windows::io::AsSocket::as_socket
     #[inline]
     #[must_use]
-    pub fn as_socket(&self) -> Option<BorrowedSocket> {
+    pub fn as_socket(&self) -> Option<BorrowedSocket<'a>> {
         unsafe {
             match self.raw.0 {
                 RawEnum::Handle(_) => None,

--- a/src/read_write.rs
+++ b/src/read_write.rs
@@ -756,17 +756,17 @@ impl<'a, RW> ReadHalf<'a, RW> {
 }
 
 #[cfg(not(windows))]
-impl<RW: AsReadWriteFd> AsFd for ReadHalf<'_, RW> {
+impl<'a, RW: AsReadWriteFd> AsFd for ReadHalf<'a, RW> {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(&self) -> BorrowedFd<'a> {
         self.0.as_read_fd()
     }
 }
 
 #[cfg(windows)]
-impl<RW: AsReadWriteHandleOrSocket> AsHandleOrSocket for ReadHalf<'_, RW> {
+impl<'a, RW: AsReadWriteHandleOrSocket> AsHandleOrSocket for ReadHalf<'a, RW> {
     #[inline]
-    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'a> {
         self.0.as_read_handle_or_socket()
     }
 }
@@ -786,17 +786,17 @@ impl<'a, RW> WriteHalf<'a, RW> {
 }
 
 #[cfg(not(windows))]
-impl<RW: AsReadWriteFd> AsFd for WriteHalf<'_, RW> {
+impl<'a, RW: AsReadWriteFd> AsFd for WriteHalf<'a, RW> {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(&self) -> BorrowedFd<'a> {
         self.0.as_write_fd()
     }
 }
 
 #[cfg(windows)]
-impl<RW: AsReadWriteHandleOrSocket> AsHandleOrSocket for WriteHalf<'_, RW> {
+impl<'a, RW: AsReadWriteHandleOrSocket> AsHandleOrSocket for WriteHalf<'a, RW> {
     #[inline]
-    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'a> {
         self.0.as_write_handle_or_socket()
     }
 }


### PR DESCRIPTION
For types like `BorrowedHandleOrSocket<'a>`, refine the lifetime of `as_handle` to return a `BorrowedHandle<'a>` rather than a `BorrowedHandle<'_>`, so that the return value can live as long as the original borrow.