### PR TITLE
Update the MSRV to Rust 1.63.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         include:
           - build: msrv
             os: ubuntu-latest
-            rust: 1.58
+            rust: 1.63
 
     steps:
     - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,16 @@ name = "io-extras"
 version = "0.17.4"
 description = "File/socket handle/descriptor utilities"
 authors = ["Dan Gohman <dev@sunfishcode.online>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 keywords = ["api", "io", "stream"]
 categories = ["os", "rust-patterns"]
 repository = "https://github.com/sunfishcode/io-extras"
 include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
-rust-version = "1.56"
+rust-version = "1.63"
 
 [dependencies]
-io-lifetimes = { version = "1.0.0", default-features = false }
+io-lifetimes = "1.1.0-pre.0"
 
 # Optionally depend on async-std to implement traits for its types.
 #
@@ -41,9 +41,9 @@ os_pipe = "1.0.0"
 
 [features]
 default = []
-use_mio_net = ["mio", "mio/net", "io-lifetimes/mio"]
-use_mio_os_ext = ["mio", "mio/os-ext", "io-lifetimes/mio"]
+use_mio_net = ["mio", "mio/net"]
+use_mio_os_ext = ["mio", "mio/os-ext"]
 use_async_std = ["async-std"]
-use_tokio = ["tokio", "io-lifetimes/tokio"]
-use_socket2 = ["socket2", "io-lifetimes/socket2"]
-use_os_pipe = ["os_pipe", "io-lifetimes/os_pipe"]
+use_tokio = ["tokio"]
+use_socket2 = ["socket2"]
+use_os_pipe = ["os_pipe"]

--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ This crate provides a few miscellaneous utilities related to I/O:
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate currently works on Rust 1.58, when default features are enabled.
+This crate currently works on Rust 1.63, when default features are enabled.
 Some of the optional features have stricter requirements.

--- a/build.rs
+++ b/build.rs
@@ -2,11 +2,6 @@ use std::env::var;
 use std::io::Write;
 
 fn main() {
-    // I/O safety is stabilized in Rust 1.63.
-    if has_io_safety() {
-        use_feature("io_lifetimes_use_std")
-    }
-
     use_feature_or_nothing("can_vector"); // https://github.com/rust-lang/rust/issues/69941
     use_feature_or_nothing("write_all_vectored"); // https://github.com/rust-lang/rust/issues/70436
 
@@ -30,6 +25,8 @@ fn has_feature(feature: &str) -> bool {
     let out_dir = var("OUT_DIR").unwrap();
     let rustc = var("RUSTC").unwrap();
 
+    use_feature("io_lifetimes_use_std");
+
     let mut child = std::process::Command::new(rustc)
         .arg("--crate-type=rlib") // Don't require `main`.
         .arg("--emit=metadata") // Do as little as possible but still parse.
@@ -41,39 +38,6 @@ fn has_feature(feature: &str) -> bool {
         .unwrap();
 
     writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
-
-    child.wait().unwrap().success()
-}
-
-/// Test whether the rustc at `var("RUSTC")` supports the I/O safety feature.
-fn has_io_safety() -> bool {
-    let out_dir = var("OUT_DIR").unwrap();
-    let rustc = var("RUSTC").unwrap();
-
-    let mut child = std::process::Command::new(rustc)
-        .arg("--crate-type=rlib") // Don't require `main`.
-        .arg("--emit=metadata") // Do as little as possible but still parse.
-        .arg("--out-dir")
-        .arg(out_dir) // Put the output somewhere inconsequential.
-        .arg("-") // Read from stdin.
-        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
-        .spawn()
-        .unwrap();
-
-    writeln!(
-        child.stdin.take().unwrap(),
-        "\
-    #[cfg(unix)]\n\
-    use std::os::unix::io::OwnedFd as Owned;\n\
-    #[cfg(target_os = \"wasi\")]\n\
-    use std::os::wasi::io::OwnedFd as Owned;\n\
-    #[cfg(windows)]\n\
-    use std::os::windows::io::OwnedHandle as Owned;\n\
-    \n\
-    pub type Success = Owned;\n\
-    "
-    )
-    .unwrap();
 
     child.wait().unwrap().success()
 }

--- a/src/os/windows/stdio.rs
+++ b/src/os/windows/stdio.rs
@@ -18,7 +18,6 @@
 
 use crate::raw::{RawReadable, RawWriteable};
 use std::char::decode_utf16;
-use std::convert::TryInto;
 use std::io::{self, Read, Write};
 use std::os::raw::c_void;
 use std::os::windows::io::{FromRawHandle, RawHandle};


### PR DESCRIPTION
This allows us to remove the checks for I/O safety in std.