### PR TITLE
Update dependencies and bump MSRV to 1.70.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         include:
           - build: msrv
             os: ubuntu-latest
-            rust: 1.63
+            rust: 1.70.0
 
     steps:
     - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ keywords = ["api", "io", "stream"]
 categories = ["os", "rust-patterns"]
 repository = "https://github.com/sunfishcode/io-extras"
 include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
-rust-version = "1.63"
+rust-version = "1.70"
 
 [dependencies]
-io-lifetimes = "2.0.0"
+io-lifetimes = "3.0.0"
 
 # Optionally depend on async-std to implement traits for its types.
 async-std = { version = "1.13.0", features = ["io_safety"], optional = true }
@@ -26,7 +26,7 @@ socket2 = { version = "0.6.0", optional = true }
 mio = { version = "1.0.2", optional = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = ">=0.52, <=0.59"
+version = ">=0.52, <=0.60"
 features = [
     "Win32_Foundation",
     "Win32_Networking_WinSock",

--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ This crate provides a few miscellaneous utilities related to I/O:
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate currently works on Rust 1.63, when default features are enabled.
+This crate currently works on Rust 1.70, when default features are enabled.
 Some of the optional features have stricter requirements.


### PR DESCRIPTION
Update io-lifetimes and windows-sys dependencies to support the latest versions.

Bump the MSRV to 1.70, to accomodate socket2 0.6.